### PR TITLE
fix version when installing

### DIFF
--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.2", "versioningit ~= 2.0.1"]
+requires = ["setuptools >= 61.2", "versioningit >= 2.2.1"]
 build-backend = 'setuptools.build_meta'
 
 [project]
@@ -20,7 +20,7 @@ classifiers = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.9"
-dependencies = ["numpy", "versioningit~=2.0.1",]
+dependencies = ["numpy", "versioningit>=2.2.1",]
 
 dynamic = ["version"]
 
@@ -184,6 +184,9 @@ ignore = ["E501"]
 # deprecated modules left
 # for backwards compatibility
 
+[tool.setuptools.cmdclass]
+sdist = "versioningit.cmdclass.sdist"
+build_py = "versioningit.cmdclass.build_py"
 
 [tool.versioningit]
 default-version = "0.0.0"


### PR DESCRIPTION
This pull request fixes the problem with versioningit by using 2.2.1 or above and adding [tool.setuptools.cmdclass]