### PR TITLE
Updated built with tag based approach on dynamic versioning based Git tags

### DIFF
--- a/{{cookiecutter.directory_name}}/docs/conf.py
+++ b/{{cookiecutter.directory_name}}/docs/conf.py
@@ -16,9 +16,10 @@
 #
 import os
 import sys
-import sphinx_rtd_theme
 import {{cookiecutter.package_name}}
+
 from packaging.version import parse
+
 sys.path.insert(0, os.path.abspath(".."))
 
 # -- Project information -----------------------------------------------------
@@ -144,29 +145,6 @@ html_theme = "sphinx_rtd_theme"
 # documentation.
 #
 # html_theme_options = {}
-
-# Add any paths that contain custom themes here, relative to this directory.
-html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-
-# The name for this set of Sphinx documents.
-# "<project> v<release> documentation" by default.
-#
-# html_title = 'Qchar v1'
-
-# A shorter title for the navigation bar.  Default is the same as html_title.
-#
-# html_short_title = None
-
-# The name of an image file (relative to this directory) to place at the top
-# of the sidebar.
-#
-# html_logo = None
-
-# The name of an image file (relative to this directory) to use as a favicon of
-# the docs.  This file should be a Windows icon file (.ico) being 16x16 or
-# 32x32 pixels large.
-#
-# html_favicon = None
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/{{cookiecutter.directory_name}}/docs/conf.py
+++ b/{{cookiecutter.directory_name}}/docs/conf.py
@@ -239,7 +239,7 @@ htmlhelp_basename = f"{project} docs"
 
 # -- Options for LaTeX output ---------------------------------------------
 
-latex_elements = {
+latex_elements: dict[str, str] = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
@@ -360,7 +360,7 @@ autodoc_default_options = {
 
 # we mock modules that for one reason or another are not
 # there when generating the docs
-autodoc_mock_imports = []
+autodoc_mock_imports: list[str] = []
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/{{cookiecutter.directory_name}}/docs/conf.py
+++ b/{{cookiecutter.directory_name}}/docs/conf.py
@@ -16,11 +16,17 @@
 #
 import os
 import sys
+import versioningit
 import {{cookiecutter.package_name}}
 
+from pathlib import Path
 from packaging.version import parse
 
 sys.path.insert(0, os.path.abspath(".."))
+# Set the project directory to the root of your project
+project_dir = Path(__file__).resolve().parent.parent
+# Get the version using versioningit
+__version__ = versioningit.get_version(project_dir=project_dir)
 
 # -- Project information -----------------------------------------------------
 

--- a/{{cookiecutter.directory_name}}/pyproject.toml
+++ b/{{cookiecutter.directory_name}}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 61.2", "versioningit ~= 2.0.1"]
+requires = ["setuptools >= 61.2", "versioningit ~= 3.1.2"]
 build-backend = 'setuptools.build_meta'
 
 [project]
@@ -20,7 +20,7 @@ classifiers = [
 ]
 license = { text = "MIT" }
 requires-python = ">=3.9"
-dependencies = ["numpy", "versioningit~=2.0.1",]
+dependencies = ["numpy", "versioningit ~= 3.1.2"]
 
 dynamic = ["version"]
 
@@ -186,7 +186,11 @@ ignore = ["E501"]
 
 
 [tool.versioningit]
-default-version = "0.0.0"
+# default-version = "2.2.1"  
+
+# Default not specified, versioningit to derive the version from Git tags
+# want versioningit to handle the version dynamically based on Git tags from remote, 
+# it's generally best to omit default-version unless you need a hardcoded fallback.
 
 [tool.versioningit.format]
 distance = "{next_version}.dev{distance}+{branch}.{vcs}{rev}"

--- a/{{cookiecutter.directory_name}}/{{cookiecutter.package_name}}/_version.py
+++ b/{{cookiecutter.directory_name}}/{{cookiecutter.package_name}}/_version.py
@@ -26,5 +26,5 @@ def _get_version() -> str:
 
 __version__ = _get_version()
 
-
+# set by default, but can be overridden in the pyproject.toml
 """ __version__ = "0.1.1" """

--- a/{{cookiecutter.directory_name}}/{{cookiecutter.package_name}}/_version.py
+++ b/{{cookiecutter.directory_name}}/{{cookiecutter.package_name}}/_version.py
@@ -1,10 +1,10 @@
 def _get_version() -> str:
     from pathlib import Path
     import versioningit
-    import nqcpdpgitforwiki
+    import {{cookiecutter.package_name}}
 
-    nqcpdpgitforwiki_path = Path(nqcpdpgitforwiki.__file__).parent
-    project_dir = nqcpdpgitforwiki_path.parent
+    path = Path({{cookiecutter.package_name}}.__file__).parent
+    project_dir = path.parent
 
     # Check if running from site-packages and it indicates that the package has been installed
     if "site-packages" in str(project_dir):
@@ -25,6 +25,3 @@ def _get_version() -> str:
     return version
 
 __version__ = _get_version()
-
-# set by default, but can be overridden in the pyproject.toml
-""" __version__ = "0.1.1" """

--- a/{{cookiecutter.directory_name}}/{{cookiecutter.package_name}}/_version.py
+++ b/{{cookiecutter.directory_name}}/{{cookiecutter.package_name}}/_version.py
@@ -1,12 +1,30 @@
 def _get_version() -> str:
     from pathlib import Path
-
     import versioningit
+    import nqcpdpgitforwiki
 
-    import {{cookiecutter.package_name}}
+    nqcpdpgitforwiki_path = Path(nqcpdpgitforwiki.__file__).parent
+    project_dir = nqcpdpgitforwiki_path.parent
 
-    {{cookiecutter.package_name}}_path = Path({{cookiecutter.package_name}}.__file__).parent
-    return versioningit.get_version(project_dir={{cookiecutter.package_name}}_path.parent)
+    # Check if running from site-packages and it indicates that the package has been installed
+    if "site-packages" in str(project_dir):
+        # Traverse up to find the root project directory
+        for parent in Path(__file__).resolve().parents:
+            if (parent / "pyproject.toml").exists():
+                project_dir = parent
+                break
 
+    if not (project_dir / "pyproject.toml").exists():
+        raise FileNotFoundError("pyproject.toml not found in the project directory")
+
+    print(f"Project directory: {project_dir}")
+
+    version = versioningit.get_version(project_dir=project_dir)
+    print(f"Retrieved version: {version}")
+
+    return version
 
 __version__ = _get_version()
+
+
+""" __version__ = "0.1.1" """


### PR DESCRIPTION
-deprecated rtd scheme
-dependency versions bump
-specific package's version retrieval logic supporting project directory, where the specific package has been installed

-this should work for both git and azure, currently tested on azure.

this approach only works with correct environment set up before installing the package build from this builder

packages are suppose to be installed with:

pip install git+https: ...

